### PR TITLE
Add keyboard-shortcuts block with interactive try-it and sheet playground

### DIFF
--- a/blocks/keyboard-shortcuts/keyboard-shortcuts.css
+++ b/blocks/keyboard-shortcuts/keyboard-shortcuts.css
@@ -1,0 +1,176 @@
+.keyboard-shortcuts {
+  --keyboard-shortcuts-accent: var(--link-color);
+  --keyboard-shortcuts-border: rgb(255 255 255 / 10%);
+  --keyboard-shortcuts-hit: #ffc857;
+
+  font-size: 0.9rem;
+}
+
+/* try-it banner */
+.keyboard-shortcuts .keyboard-shortcuts-tryit {
+  margin: 0 0 1.25rem;
+  padding: 0 0 0.75rem;
+  border-bottom: 1px solid var(--keyboard-shortcuts-border);
+  font-family: var(--fixed-font-family);
+  font-size: 0.78rem;
+  color: rgb(255 255 255 / 55%);
+  letter-spacing: 0.01em;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-sections {
+  column-width: 16rem;
+  column-count: 2;
+  column-gap: 2.5rem;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-section {
+  min-width: 0;
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-section h3 {
+  margin: 0 0 0.35rem;
+  padding: 0 0 0.35rem;
+  border-bottom: 1px solid var(--keyboard-shortcuts-border);
+  font-family: var(--heading-font-family);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgb(255 255 255 / 45%);
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.3rem 0.4rem;
+  margin: 0 -0.4rem;
+  border-radius: 0.3rem;
+  line-height: 1.3;
+  transition: background 0.15s ease;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-list li:hover {
+  background: rgb(0 0 0 / 15%);
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-action {
+  flex: 1;
+  color: var(--text-color);
+}
+
+.keyboard-shortcuts kbd {
+  display: inline-block;
+  padding: 0.05em 0.4em;
+  margin: 0 0.05em;
+  font-family: var(--fixed-font-family);
+  font-size: 0.78em;
+  font-weight: 500;
+  color: rgb(255 255 255 / 85%);
+  background: rgb(255 255 255 / 6%);
+  border: 1px solid var(--keyboard-shortcuts-border);
+  border-radius: 0.3rem;
+  white-space: nowrap;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-combo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15em;
+  color: rgb(255 255 255 / 35%);
+  font-size: 0.85em;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-note {
+  color: rgb(255 255 255 / 45%);
+  font-size: 0.8em;
+}
+
+/* sheet variant: live jspreadsheet grid the reader can try shortcuts in */
+.keyboard-shortcuts .keyboard-shortcuts-playground {
+  margin: 0 0 1.5rem;
+}
+
+.keyboard-shortcuts .keyboard-shortcuts-playground-grid {
+  overflow-x: auto;
+  border: 1px solid var(--keyboard-shortcuts-border);
+  border-radius: 0.4rem;
+}
+
+/* jspreadsheet ships a light-only skin: its cells inherit our page's white
+   text color onto its white background, so it needs an explicit dark skin
+   rather than just a border wrapper. Its class names use underscores, not
+   our kebab-case convention, since they belong to the vendor's stylesheet */
+/* stylelint-disable-next-line selector-class-pattern */
+.keyboard-shortcuts-playground-grid .jexcel_container,
+.keyboard-shortcuts-playground-grid .jexcel {
+  background-color: var(--background-color-2);
+  border-color: var(--keyboard-shortcuts-border);
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.keyboard-shortcuts-playground-grid .jexcel_content {
+  scrollbar-color: rgb(255 255 255 / 30%) transparent;
+}
+
+.keyboard-shortcuts-playground-grid .jexcel > tbody > tr > td {
+  border-color: var(--keyboard-shortcuts-border);
+  color: var(--text-color);
+}
+
+.keyboard-shortcuts-playground-grid .jexcel > thead > tr > td,
+.keyboard-shortcuts-playground-grid .jexcel > tfoot > tr > td,
+.keyboard-shortcuts-playground-grid .jexcel > tbody > tr > td:first-child {
+  background-color: var(--background-color);
+  border-color: var(--keyboard-shortcuts-border);
+  color: rgb(255 255 255 / 55%);
+}
+
+.keyboard-shortcuts-playground-grid .jexcel > thead > tr > td.selected,
+.keyboard-shortcuts-playground-grid .jexcel > tbody > tr.selected > td:first-child {
+  background-color: var(--background-color-2);
+  color: var(--text-color);
+}
+
+.keyboard-shortcuts-playground-grid .jexcel > tbody > tr > td.readonly {
+  color: rgb(255 255 255 / 30%);
+}
+
+.keyboard-shortcuts-playground-grid .jexcel .highlight,
+.keyboard-shortcuts-playground-grid .jexcel .selection {
+  background-color: rgb(255 255 255 / 8%);
+}
+
+.keyboard-shortcuts-playground-grid .jexcel .highlight-top,
+.keyboard-shortcuts-playground-grid .jexcel .highlight-left,
+.keyboard-shortcuts-playground-grid .jexcel .highlight-right,
+.keyboard-shortcuts-playground-grid .jexcel .highlight-bottom {
+  border-color: var(--keyboard-shortcuts-accent);
+  box-shadow: none;
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.keyboard-shortcuts-playground-grid .jexcel_corner {
+  background-color: var(--keyboard-shortcuts-accent);
+  border-color: var(--background-color-2);
+}
+
+/* hit / active state */
+.keyboard-shortcuts li.keyboard-shortcuts-hit .keyboard-shortcuts-action {
+  color: var(--keyboard-shortcuts-hit);
+}
+
+.keyboard-shortcuts li.keyboard-shortcuts-hit kbd {
+  color: #1a1406;
+  background: var(--keyboard-shortcuts-hit);
+  border-color: var(--keyboard-shortcuts-hit);
+}

--- a/blocks/keyboard-shortcuts/keyboard-shortcuts.js
+++ b/blocks/keyboard-shortcuts/keyboard-shortcuts.js
@@ -1,0 +1,214 @@
+import { loadCSS, loadScript } from '../../scripts/aem.js';
+
+const IS_MAC = /Mac|iPhone|iPad/i.test(navigator.platform);
+
+/* jspreadsheet-ce is the same engine DA sheets run on, loaded on demand so
+   the sheet playground's weight is paid only by pages that use it */
+const JSUITES_JS = 'https://cdn.jsdelivr.net/npm/jsuites@5/dist/jsuites.js';
+const JSUITES_CSS = 'https://cdn.jsdelivr.net/npm/jsuites@5/dist/jsuites.css';
+const JSPREADSHEET_JS = 'https://cdn.jsdelivr.net/npm/jspreadsheet-ce@4/dist/index.js';
+const JSPREADSHEET_CSS = 'https://cdn.jsdelivr.net/npm/jspreadsheet-ce@4/dist/jspreadsheet.css';
+
+const PLAYGROUND_DATA = [
+  ['Write the shortcuts post', 'Content', 'Done'],
+  ['Build the sheet demo', 'Engineering', 'In progress'],
+  ['QA on mobile', 'Design', 'Not started'],
+  ['Schedule publish', 'Content', 'Not started'],
+];
+
+const PLAYGROUND_COLUMNS = [
+  { title: 'Task', width: 220 },
+  { title: 'Team', width: 140 },
+  { title: 'Status', width: 140 },
+];
+
+const KEY_LABELS = {
+  mod: IS_MAC ? '⌘' : 'Ctrl',
+  cmd: '⌘',
+  ctrl: IS_MAC ? '⌃' : 'Ctrl',
+  alt: IS_MAC ? '⌥' : 'Alt',
+  shift: IS_MAC ? '⇧' : 'Shift',
+  enter: '↵ Enter',
+  backspace: '⌫',
+  delete: 'Del',
+  space: 'Space',
+  esc: 'Esc',
+  tab: 'Tab',
+  f2: 'F2',
+  home: 'Home',
+  end: 'End',
+  arrow: '←↑↓→',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+};
+
+/* trailing "(some note)" on a keys cell, e.g. "Enter (adds a row on the last row)" */
+const NOTE_RE = /\s*(\([^)]*\))\s*$/;
+
+/* "Ctrl" is a literal, platform-invariant key (used e.g. for spreadsheet
+   Ctrl+Arrow, which is Ctrl on both Mac and Windows, unlike Mod). On
+   non-Mac it's physically the same key as Mod, so normalize it for matching
+   real keydown events, which can't otherwise tell the two apart */
+function normalizeKeyForMatch(key) {
+  return key === 'ctrl' && !IS_MAC ? 'mod' : key;
+}
+
+/* Turn "Mod+Shift+Z" into a row of <kbd> keycaps */
+function renderCombo(combo) {
+  const span = document.createElement('span');
+  span.className = 'keyboard-shortcuts-combo';
+  span.dataset.combo = combo
+    .toLowerCase()
+    .replace(/\s/g, '')
+    .split('+')
+    .map(normalizeKeyForMatch)
+    .join('+');
+  combo.split('+').forEach((key, i) => {
+    if (i > 0) span.append('+');
+    const kbd = document.createElement('kbd');
+    kbd.textContent = KEY_LABELS[key.trim().toLowerCase()] || key.trim();
+    span.append(kbd);
+  });
+  return span;
+}
+
+/* Turn "Mod+B / Mod+I" or free text into rendered keys, with an optional
+   trailing parenthetical note rendered as muted text rather than a keycap */
+function renderKeys(text) {
+  const frag = document.createDocumentFragment();
+  const parts = text.split(' / ');
+  parts.forEach((part, i) => {
+    if (i > 0) frag.append(' or ');
+    let keys = part.trim();
+    const noteMatch = keys.match(NOTE_RE);
+    const note = noteMatch ? noteMatch[1] : null;
+    if (noteMatch) keys = keys.slice(0, noteMatch.index).trim();
+    if (keys.includes('+') || KEY_LABELS[keys.toLowerCase()]) {
+      frag.append(renderCombo(keys));
+    } else {
+      frag.append(keys); // free text like "type --- then Enter"
+    }
+    if (note) {
+      const noteEl = document.createElement('span');
+      noteEl.className = 'keyboard-shortcuts-note';
+      noteEl.textContent = ` ${note}`;
+      frag.append(noteEl);
+    }
+  });
+  return frag;
+}
+
+/* Build a normalized combo string from a real keydown event */
+function eventToCombo(e) {
+  const parts = [];
+  if (IS_MAC ? e.metaKey : e.ctrlKey) parts.push('mod');
+  else if (e.ctrlKey) parts.push('ctrl');
+  if (e.altKey) parts.push('alt');
+  if (e.shiftKey) parts.push('shift');
+  let key = e.key.toLowerCase();
+  if (key.startsWith('arrow')) key = 'arrow';
+  if (!['meta', 'control', 'alt', 'shift'].includes(key)) parts.push(key);
+  return parts.join('+');
+}
+
+/* Highlight the row whose combo matches, scrolling it into view */
+function highlightMatch(block, combo) {
+  block.querySelectorAll('.keyboard-shortcuts-hit').forEach((el) => el.classList.remove('keyboard-shortcuts-hit'));
+  const match = block.querySelector(`[data-combo="${combo}"]`);
+  if (!match) return false;
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const row = match.closest('li');
+  row.classList.add('keyboard-shortcuts-hit');
+  row.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+  return true;
+}
+
+/* Doc-editor variant: shortcuts double as page/browser shortcuts too, so
+   listen globally and let any matching keydown light up its row */
+function enableTryIt(block) {
+  const banner = document.createElement('p');
+  banner.className = 'keyboard-shortcuts-tryit';
+  banner.textContent = '⌨️ Try it: press any shortcut below to light it up.';
+  block.prepend(banner);
+
+  document.addEventListener('keydown', (e) => {
+    if (highlightMatch(block, eventToCombo(e))) e.preventDefault();
+  });
+}
+
+/* Sheet variant: instead of simulating shortcuts, embed a real jspreadsheet
+   grid (the same engine DA sheets use) so every binding — F2, Alt+Enter,
+   Ctrl+Arrow, Ctrl+S — genuinely works. Capture is inherently focus-scoped:
+   we only ever see keydowns that bubble out of the grid's own focused cell,
+   so arrows/Tab/Space never hijack the surrounding page. We just observe
+   and highlight; the grid handles its own defaults natively */
+async function enableSheetPlayground(block) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'keyboard-shortcuts-playground';
+
+  const caption = document.createElement('p');
+  caption.className = 'keyboard-shortcuts-tryit';
+  caption.textContent = '⌨️ This is a live grid running the same engine as DA sheets — click a cell, then try a shortcut below.';
+
+  const mount = document.createElement('div');
+  mount.className = 'keyboard-shortcuts-playground-grid';
+
+  wrapper.append(caption, mount);
+  block.prepend(wrapper);
+
+  try {
+    await loadScript(JSUITES_JS);
+    await loadCSS(JSUITES_CSS);
+    await loadScript(JSPREADSHEET_JS);
+    await loadCSS(JSPREADSHEET_CSS);
+
+    window.jspreadsheet(mount, {
+      data: PLAYGROUND_DATA,
+      columns: PLAYGROUND_COLUMNS,
+    });
+
+    mount.addEventListener('keydown', (e) => highlightMatch(block, eventToCombo(e)));
+  } catch {
+    caption.textContent = 'The live grid could not load. The shortcuts below still work as a reference.';
+  }
+}
+
+export default function decorate(block) {
+  const sections = document.createElement('div');
+  sections.className = 'keyboard-shortcuts-sections';
+
+  let list;
+
+  [...block.children].forEach((row) => {
+    const cells = [...row.children];
+    if (cells.length === 1) {
+      // single-cell row = section heading
+      const section = document.createElement('div');
+      section.className = 'keyboard-shortcuts-section';
+      const h3 = document.createElement('h3');
+      h3.textContent = cells[0].textContent.trim();
+      list = document.createElement('ul');
+      list.className = 'keyboard-shortcuts-list';
+      section.append(h3, list);
+      sections.append(section);
+      return;
+    }
+    const [action, keys] = cells;
+    const li = document.createElement('li');
+    const label = document.createElement('span');
+    label.className = 'keyboard-shortcuts-action';
+    label.textContent = action.textContent.trim();
+    li.append(label, renderKeys(keys.textContent.trim()));
+    list.append(li);
+  });
+
+  block.textContent = '';
+  block.append(sections);
+
+  if (block.classList.contains('interactive')) {
+    if (block.classList.contains('sheet')) enableSheetPlayground(block);
+    else enableTryIt(block);
+  }
+}


### PR DESCRIPTION
Renders grouped shortcut reference cards with a compact, fluid multi-column layout and row hover/hit highlighting. Supports two interactive variants: a global keydown listener that lights up the matching row, and a live jspreadsheet-ce grid so sheet shortcuts (F2, Ctrl+Arrow, Alt+Enter, etc.) can be tried against a real grid instead of just simulated.

- Before: https://main--arbory-da--arbory-digital-inc.aem.page/0-sandbox/frank/da-keyboard-shortcuts-copy
- After: https://shortcuts--arbory-da--arbory-digital-inc.aem.page/0-sandbox/frank/da-keyboard-shortcuts-copy
