### PR TITLE
Auto-embed bare YouTube links and round standalone body images

### DIFF
--- a/blocks/youtube/youtube.css
+++ b/blocks/youtube/youtube.css
@@ -1,0 +1,1 @@
+@import url('../embed/embed.css');

--- a/blocks/youtube/youtube.js
+++ b/blocks/youtube/youtube.js
@@ -1,0 +1,20 @@
+/*
+ * Youtube Block
+ * Auto-blocks a bare YouTube link on its own line into the embed player.
+ */
+
+import decorateEmbed from '../embed/embed.js';
+
+export default function decorate(block) {
+  const href = block.tagName === 'A' ? block.href : block.querySelector('a')?.href;
+  const embedBlock = document.createElement('div');
+  embedBlock.className = 'block embed';
+
+  const link = document.createElement('a');
+  link.href = href;
+  link.textContent = href;
+  embedBlock.append(link);
+
+  block.replaceWith(embedBlock);
+  decorateEmbed(embedBlock);
+}

--- a/scripts/nx.js
+++ b/scripts/nx.js
@@ -2,7 +2,10 @@ const AUTO_BLOCKS = [{
   fragment: '/fragments/',
 },
 {
-  youtube: 'https://www.youtube',
+  youtube: 'youtube.com',
+},
+{
+  youtube: 'youtu.be',
 },
 ];
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -276,6 +276,11 @@ main img {
   height: auto;
 }
 
+main .default-content-wrapper > p > picture:only-child img {
+  border-radius: 1rem;
+  box-shadow: var(--shadow-xl);
+}
+
 .icon {
   display: inline-block;
   height: 24px;


### PR DESCRIPTION
Broaden YouTube auto-block matching and add a youtube block that delegates to the existing embed player, giving bare YouTube links on their own line the same rounded/shadowed embed styling. Also apply that rounded-corner look to standalone images in body text.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--arbory-da--arbory-digital-inc.aem.page/en/
- After: https://<branch>--arbory-da--arbory-digital-inc.aem.page/en/
